### PR TITLE
Fix Files API and MFS API definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -38,7 +38,7 @@ declare class IPFS extends EventEmitter {
     dag: IPFS.DagAPI;
     libp2p: any;
     swarm: IPFS.SwarmAPI;
-    files: IPFS.FilesAPI;
+    files: any;
     bitswap: any;
 
     ping(callback: (error: Error) => void): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -38,7 +38,7 @@ declare class IPFS extends EventEmitter {
     dag: IPFS.DagAPI;
     libp2p: any;
     swarm: IPFS.SwarmAPI;
-    files: any;
+    files: IPFS.FilesAPI;
     bitswap: any;
 
     ping(callback: (error: Error) => void): void;
@@ -162,23 +162,19 @@ declare namespace IPFS {
     }
 
     export interface FilesAPI {
-        createAddStream(options: any, callback: Callback<any>): void;
-        createAddStream(callback: Callback<any>): void;
-
-        createPullStream(options: any): any;
-
-        add(data: FileContent, options: any, callback: Callback<IPFSFile[]>): void;
-        add(data: FileContent, options: any): Promise<IPFSFile[]>;
-        add(data: FileContent, callback: Callback<IPFSFile[]>): void;
-        add(data: FileContent): Promise<IPFSFile[]>;
-
-        cat(hash: Multihash, callback: Callback<FileContent>): void;
-        cat(hash: Multihash): Promise<FileContent>;
-
-        get(hash: Multihash, callback: Callback<IPFSFile[]>): void;
-        get(hash: Multihash): Promise<IPFSFile[]>;
-
-        getPull(hash: Multihash, callback: Callback<any>): void;
+        cp: any
+        flush: any
+        ls: any
+        lsReadableStream: any
+        lsPullStream: any
+        mkdir: any
+        mv: any
+        read: any
+        readPullStream: any
+        readReadableStream: any
+        rm: any
+        stat: any
+        write: any
     }
 
     export interface PeersOptions {

--- a/index.d.ts
+++ b/index.d.ts
@@ -47,17 +47,45 @@ declare class IPFS extends EventEmitter {
     pubsub: any;
     dht: any;
     pin: any;
+
     // Top level Files API
     add(data: IPFS.FileContent, options: any, callback: Callback<IPFS.IPFSFile[]>): void;
     add(data: IPFS.FileContent, options: any): Promise<IPFS.IPFSFile[]>;
     add(data: IPFS.FileContent, callback: Callback<IPFS.IPFSFile[]>): void;
     add(data: IPFS.FileContent): Promise<IPFS.IPFSFile[]>;
 
+    addFromStream(stream: any, options?: any): Promise<IPFS.IPFSFile[]>
+    addFromStream(stream: any, callback: Callback<IPFS.IPFSFile[]>): void;
+    addFromStream(stream: any, options: any, callback: Callback<IPFS.IPFSFile[]>): void;
+
+    addFromUrl(url: string, options: any, callback: Callback<IPFS.IPFSFile[]>): void;
+    addFromUrl(url: string, options: any): Promise<IPFS.IPFSFile[]>;
+    addFromUrl(url: string, callback: Callback<IPFS.IPFSFile[]>): void;
+    addFromUrl(url: string): Promise<IPFS.IPFSFile[]>;
+
+    addFromFs(path: string, options: any, callback: Callback<IPFS.IPFSFile[]>): void;
+    addFromFs(path: string, options: any): Promise<IPFS.IPFSFile[]>;
+    addFromFs(path: string, callback: Callback<IPFS.IPFSFile[]>): void;
+    addFromFs(path: string): Promise<IPFS.IPFSFile[]>;
+
+    addPullStream(options?: any): any;
+    addReadableStream(options?: any): any;
+
     cat(hash: IPFS.Multihash, callback: Callback<IPFS.FileContent>): void;
-    cat(hash: IPFS.Multihash): Promise<IPFS.FileContent>;
+    cat(hash: IPFS.Multihash, options: any, callback: Callback<IPFS.FileContent>): void;
+    cat(hash: IPFS.Multihash, options?: any): Promise<IPFS.FileContent>;
+    catPullStream(hash: IPFS.Multihash, options?: any): any;
+    catReadableStream(hash: IPFS.Multihash, options?: any): any;
 
     get(hash: IPFS.Multihash, callback: Callback<IPFS.IPFSFile[]>): void;
     get(hash: IPFS.Multihash): Promise<IPFS.IPFSFile[]>;
+    getPullStream(hash: IPFS.Multihash): any;
+    getReadableStream(hash: IPFS.Multihash): any;
+
+    ls(hash: IPFS.Multihash): Promise<IPFS.IPFSFileInfo[]>;
+    lsPullStream(hash: IPFS.Multihash): any;
+    lsReadableStream(hash: IPFS.Multihash): any;
+
 }
 
 declare namespace IPFS {
@@ -123,6 +151,14 @@ declare namespace IPFS {
         hash: string;
         size: number;
         content?: FileContent;
+    }
+    export interface IPFSFileInfo {
+        path: string;
+        hash: string;
+        size: number;
+        name: string;
+        depth: number;
+        type: 'file' | 'dir' | string;
     }
 
     export interface FilesAPI {

--- a/index.d.ts
+++ b/index.d.ts
@@ -44,7 +44,10 @@ declare class IPFS extends EventEmitter {
     ping(callback: (error: Error) => void): void;
     ping(): Promise<void>;
 
-    pubsub: any; 
+    pubsub: any;
+    
+    // Top level API
+    add(data: any, options?: any): Promise<IPFSFile[]>
 }
 
 declare namespace IPFS {

--- a/index.d.ts
+++ b/index.d.ts
@@ -45,9 +45,19 @@ declare class IPFS extends EventEmitter {
     ping(): Promise<void>;
 
     pubsub: any;
-    
-    // Top level API
-    add(data: any, options?: any): Promise<IPFSFile[]>
+    dht: any;
+    pin: any;
+    // Top level Files API
+    add(data: IPFS.FileContent, options: any, callback: Callback<IPFS.IPFSFile[]>): void;
+    add(data: IPFS.FileContent, options: any): Promise<IPFS.IPFSFile[]>;
+    add(data: IPFS.FileContent, callback: Callback<IPFS.IPFSFile[]>): void;
+    add(data: IPFS.FileContent): Promise<IPFS.IPFSFile[]>;
+
+    cat(hash: IPFS.Multihash, callback: Callback<IPFS.FileContent>): void;
+    cat(hash: IPFS.Multihash): Promise<IPFS.FileContent>;
+
+    get(hash: IPFS.Multihash, callback: Callback<IPFS.IPFSFile[]>): void;
+    get(hash: IPFS.Multihash): Promise<IPFS.IPFSFile[]>;
 }
 
 declare namespace IPFS {


### PR DESCRIPTION
The definition of the regular "files API" as well as the MFS API is wrong.

In these type definitions, methods from the files API are defined under `ipfs.files`.
In reality all of them are top level, e.g. `ipfs.add`, `ipfs.get`, etc.

See: https://github.com/ipfs/interface-js-ipfs-core/blob/master/SPEC/FILES.md

With the current definition it's impossible to invoke these methods since they don't exist.
I proceeded to fix this, and moved these functions from `ipfs.files` to the top level.
I also fixed some and added missing ones.

What should actually be under `ipfs.files` is the *MFS* API, which has very different functions.
I've added "stub" definitions for it so it can be used (mapping all individual calls to `any`), although in the future someone should make a proper definition.

In addition to this, I have defined two additional top level objects:
```Typescript
dht: any
pin: any
```
Representing the new DHT and Pin APIs that have been added to js-ipfs