### PR TITLE
Add _idB58String property to PeerInfo

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -186,6 +186,7 @@ declare namespace IPFS {
 
     export interface PeerInfo {
         id: PeerId;
+        _idB58String: string;
         multiaddr: Multiaddr;
         multiaddrs: Multiaddr[];
         distinctMultiaddr(): Multiaddr[];


### PR DESCRIPTION
Adding missing property to PeerInfo object.
It's the only way of getting the string representation of the id from a peer object, as id is a Uint8Array, and its toString() method gives an invalid string